### PR TITLE
Disable removeScriptTags plugin

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ server.use(prerender.sendPrerenderHeader());
 // server.use(prerender.whitelist());
 server.use(prerender.blacklist());
 // server.use(prerender.logger());
-server.use(prerender.removeScriptTags());
+// server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 server.use(require('prerender-mongodb-cache'));
 // server.use(prerender.inMemoryHtmlCache());


### PR DESCRIPTION
Нужно как минимум для http://m15.ua, так как для него все запросы (в частности от браузеров) пропускаются через prerender.